### PR TITLE
up_from_bottom animation fix

### DIFF
--- a/res/anim/up_from_bottom.xml
+++ b/res/anim/up_from_bottom.xml
@@ -19,7 +19,8 @@
 -->
 
 <set xmlns:android="http://schemas.android.com/apk/res/android"
-     android:shareInterpolator="@android:anim/decelerate_interpolator">
+     android:shareInterpolator="true"
+     android:interpolator="@android:anim/decelerate_interpolator">
     <translate
         android:fromXDelta="0%" android:toXDelta="0%"
         android:fromYDelta="100%" android:toYDelta="0%"


### PR DESCRIPTION
Wrong attributes used, android:shareInterpolator must be a boolean, and the android:interpolator attribute has to be added to apply the animation to all the children in the <set>-element.
